### PR TITLE
Added Notification Controller reference to base

### DIFF
--- a/dist/amd/index.js
+++ b/dist/amd/index.js
@@ -1,4 +1,4 @@
-define(['exports', './notification-renderer', './bs-notification', './notification-level', './notification-service'], function (exports, _notificationRenderer, _bsNotification, _notificationLevel, _notificationService) {
+define(['exports', './notification-renderer', './bs-notification', './notification-level', './notification-service', './notification-controller'], function (exports, _notificationRenderer, _bsNotification, _notificationLevel, _notificationService, _notificationController) {
   'use strict';
 
   exports.__esModule = true;
@@ -13,6 +13,8 @@ define(['exports', './notification-renderer', './bs-notification', './notificati
   _defaults(exports, _interopExportWildcard(_notificationLevel, _defaults));
 
   _defaults(exports, _interopExportWildcard(_notificationService, _defaults));
+
+  _defaults(exports, _interopExportWildcard(_notificationController, _defaults));
 
   function configure(config, callback) {
     config.globalResources('./bs-notification');

--- a/dist/commonjs/index.js
+++ b/dist/commonjs/index.js
@@ -21,6 +21,10 @@ var _notificationService = require('./notification-service');
 
 _defaults(exports, _interopExportWildcard(_notificationService, _defaults));
 
+var _notificationController = require('./notification-controller');
+
+_defaults(exports, _interopExportWildcard(_notificationController, _defaults));
+
 function configure(config, callback) {
   config.globalResources('./bs-notification');
 

--- a/dist/es6/index.js
+++ b/dist/es6/index.js
@@ -3,6 +3,7 @@ import {globalSettings} from './notification-renderer';
 export * from './bs-notification';
 export * from './notification-level';
 export * from './notification-service';
+export * from './notification-controller';
 
 export function configure(config, callback) {
   config.globalResources(

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -1,4 +1,4 @@
-System.register(['./notification-renderer', './bs-notification', './notification-level', './notification-service'], function (_export) {
+System.register(['./notification-renderer', './bs-notification', './notification-level', './notification-service', './notification-controller'], function (_export) {
   'use strict';
 
   var globalSettings;
@@ -27,6 +27,10 @@ System.register(['./notification-renderer', './bs-notification', './notification
     }, function (_notificationService) {
       for (var _key3 in _notificationService) {
         if (_key3 !== 'default') _export(_key3, _notificationService[_key3]);
+      }
+    }, function (_notificationController) {
+      for (var _key4 in _notificationController) {
+        if (_key4 !== 'default') _export(_key4, _notificationController[_key4]);
       }
     }],
     execute: function () {}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import {globalSettings} from './notification-renderer';
 export * from './bs-notification';
 export * from './notification-level';
 export * from './notification-service';
+export * from './notification-controller';
 
 export function configure(config, callback) {
   config.globalResources(


### PR DESCRIPTION
Hi, I wanted/needed to use a custom viewModel for the notification.  You didn't have the Notification Controller in a way I could import it into my new viewModel.  I have exported it in the index.js file along with the other items.  That's the only change I made.
## Thanks and great work!

Chris
